### PR TITLE
Fix CUE-files parsing for very long records

### DIFF
--- a/src/foobnix/cue/cue_reader.py
+++ b/src/foobnix/cue/cue_reader.py
@@ -44,7 +44,7 @@ class CueTrack():
     def get_start_time_sec(self):
         time = self.get_start_time_str()
 
-        times = re.findall("([0-9]{1,2}):", time)
+	times = re.findall("([0-9]{1,3}):", time)
 
         if not times or len(times) < 2:
             return 0


### PR DESCRIPTION
Some records are longer than 100 minutes so they could contain
CUE-track entries with 3-digits "INDEX 01" value.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
