### PR TITLE
Fix duplicated Comment entry

### DIFF
--- a/share/applications/foobnix.desktop
+++ b/share/applications/foobnix.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Name=Foobnix
-Comment=Short description
 GenericName=Music Player
 GenericName[ru]=Плеер музыки
 X-GNOME-FullName=Foobnix Music Player


### PR DESCRIPTION
Remove duplicated "Comment" entry from the *.desktop file.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
