### PR TITLE
Update list_utils.py

### DIFF
--- a/foobnix/util/list_utils.py
+++ b/foobnix/util/list_utils.py
@@ -28,7 +28,7 @@ def get_song_number(text):
 def comparator(x, y):
     value_x = get_song_number(x)
     value_y = get_song_number(y)
-    if value_x and value_y:
+    if value_x and value_y and value_x != value_y:
         return value_x - value_y
     else:
         return cmp(x, y)


### PR DESCRIPTION
В случае, если названия файлов с музыкой начинается не с номера композиции, а, например, указания исполнителя или года записи (например, "65daysofstatic - The Fall of Math - 05 - I Swallowed Hard, Like I Understood.mp3") функция get_song_number вместо номера трека может возвращать некорректное значение, обычно одинаковое для всех треков в альбоме (в приведённом примере — 65). Предлагаемое добавление проверки на равенство полученных номеров треков должно позволить корректно обрабатывать подобные ситуации и сортировать в подобных случаях треки в алфавитном порядке.