### PR TITLE
Update MPRIS D-Bus interface implementation

### DIFF
--- a/foobnix/gui/base_controls.py
+++ b/foobnix/gui/base_controls.py
@@ -784,3 +784,11 @@ class BaseFoobnixControls():
 
     def download(self):
         self.dm.append_task(bean=self.notetabs.get_current_tree().get_current_bean_by_UUID())
+
+    @property
+    def position_microseconds(self):
+        return self.media_engine.position_sec * 1000000
+
+    @property
+    def duration_microseconds(self):
+        return self.media_engine.duration_sec * 1000000

--- a/foobnix/gui/base_controls.py
+++ b/foobnix/gui/base_controls.py
@@ -510,8 +510,25 @@ class BaseFoobnixControls():
         self.media_engine.seek(percent)
 
     @idle_task
+    def player_seek_microseconds(self, time_us, offset=0.0):
+        percent = 100.0 * (offset + time_us) / self.duration_microseconds
+        if percent > 100.0:
+            percent = 100.0
+        elif percent < 0.0:
+            percent = 0.0
+        self.player_seek(percent)
+
+    @idle_task
+    def player_seek_microseconds_relative(self, time_us):
+        self.player_seek_microseconds(time_us, offset=self.position_microseconds)
+
+    @idle_task
     def player_volume(self, percent):
         self.media_engine.volume(percent)
+        self.volume.set_value(percent)
+
+    def get_player_volume(self):
+        return self.volume.get_value()
 
     def search_vk_page_tracks(self, vk_ulr):
         logging.debug("Search vk_service page tracks")

--- a/foobnix/gui/controls/dbus_manager.py
+++ b/foobnix/gui/controls/dbus_manager.py
@@ -247,6 +247,23 @@ class MprisSoundMenu(SoundMenuControls):
     def _sound_menu_quit(self):
         self.controls.quit()
 
+    def _sound_menu_seek(self, offset):
+        self.controls.player_seek_microseconds_relative(offset)
+
+    def _sound_menu_set_position(self, position):
+        self.controls.player_seek_microseconds(position)
+
+    def _sound_menu_get_volume(self):
+        return self.controls.get_player_volume() / 100.0
+
+    def _sound_menu_set_volume(self, value):
+        if value > 1.0:
+            value = 1.0
+        elif value < 0.0:
+            value = 0.0
+
+        return self.controls.player_volume(100.0*value)
+
     @property
     def position_microseconds(self):
         return self.controls.position_microseconds

--- a/foobnix/gui/controls/dbus_manager.py
+++ b/foobnix/gui/controls/dbus_manager.py
@@ -217,7 +217,7 @@ class MprisPlayer(dbus.service.Object):
 class MprisSoundMenu(SoundMenuControls):
     def __init__(self, controls):
         self.controls = controls
-        SoundMenuControls.__init__(self, "foobnix")
+        SoundMenuControls.__init__(self, "foobnix %s" % FOOBNIX_VERSION, "foobnix")
 
 
     def _sound_menu_next(self):
@@ -234,18 +234,17 @@ class MprisSoundMenu(SoundMenuControls):
 
     def _sound_menu_pause(self):
         self.controls.state_pause()
+    
+    def _sound_menu_stop(self):
+        self.controls.state_stop()
 
     @idle_task
     def _sound_menu_raise(self):
         self.controls.main_window.show()
-
-    @dbus.service.method('org.mpris.MediaPlayer2.Player')
-    def Stop(self):
-        self.controls.state_stop()
-
-    @dbus.service.method('org.mpris.MediaPlayer2.Player')
-    def Play(self):
-        self.controls.state_play()
+    
+    @idle_task
+    def _sound_menu_quit(self):
+        self.controls.quit()
 
 
 def foobnix_dbus_interface():

--- a/foobnix/gui/controls/dbus_manager.py
+++ b/foobnix/gui/controls/dbus_manager.py
@@ -76,7 +76,8 @@ class DBusManager():
         self.sound_menu.song_changed(artists=artists,
                                      title=bean.title or bean.text,
                                      album=bean.album,
-                                     cover=image)
+                                     cover=image,
+                                     duration_microsec=self.sound_menu.duration_microseconds)
 
     def on_mediakey(self, comes_from, what):
         if not FC().media_keys_enabled:
@@ -245,6 +246,14 @@ class MprisSoundMenu(SoundMenuControls):
     @idle_task
     def _sound_menu_quit(self):
         self.controls.quit()
+
+    @property
+    def position_microseconds(self):
+        return self.controls.position_microseconds
+
+    @property
+    def duration_microseconds(self):
+        return self.controls.duration_microseconds
 
 
 def foobnix_dbus_interface():

--- a/foobnix/gui/controls/dbus_manager.py
+++ b/foobnix/gui/controls/dbus_manager.py
@@ -14,7 +14,7 @@ from foobnix.version import FOOBNIX_VERSION
 from dbus.mainloop.glib import DBusGMainLoop
 from foobnix.gui.service.path_service import get_foobnix_resourse_path_by_name
 from foobnix.thirdparty.sound_menu import SoundMenuControls
-from foobnix.util.const import STATE_PLAY, ICON_FOOBNIX
+from foobnix.util.const import STATE_PLAY, ICON_FOOBNIX, FTYPE_RADIO
 
 DBusGMainLoop(set_as_default=True)
 
@@ -73,11 +73,16 @@ class DBusManager():
         artists = None
         if bean.artist:
             artists = [bean.artist]
+        properties = {
+            "CanPause": bean.type != FTYPE_RADIO,
+            "CanSeek": bean.type != FTYPE_RADIO
+            }
         self.sound_menu.song_changed(artists=artists,
                                      title=bean.title or bean.text,
                                      album=bean.album,
                                      cover=image,
-                                     duration_microsec=self.sound_menu.duration_microseconds)
+                                     duration_microsec=self.sound_menu.duration_microseconds,
+                                     properties=properties)
 
     def on_mediakey(self, comes_from, what):
         if not FC().media_keys_enabled:

--- a/foobnix/gui/controls/volume.py
+++ b/foobnix/gui/controls/volume.py
@@ -45,7 +45,7 @@ class VolumeControls(LoadSave, Gtk.Box, FControl):
         self.on_save()
 
     def get_value(self):
-        self.volume_scale.get_value()
+        return self.volume_scale.get_value()
 
     def set_value(self, value):
         self.volume_scale.set_value(value)

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -206,6 +206,7 @@ class SoundMenuControls(dbus.service.Object):
 
         self.set_property("Metadata", dbus.Dictionary(data, "sv", variant_level=1))
         self.set_properties(**properties)
+        self.properties_changed("Metadata", *properties.keys())
 
     @staticmethod
     def _get_track_id(title):
@@ -398,7 +399,7 @@ class SoundMenuControls(dbus.service.Object):
         """
 
         self.set_property("PlaybackStatus", "Playing")
-        self.properties_changed("Metadata", "PlaybackStatus")
+        self.properties_changed("PlaybackStatus")
 
     def signal_paused(self):
         """signal_paused - Tell the Sound Menu that the player has

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -202,7 +202,7 @@ class SoundMenuControls(dbus.service.Object):
 
     @staticmethod
     def _get_track_id(title):
-        return "".join(filter(str.isalnum, title))
+        return "".join(filter(str.isalnum, str(title)))
 
     @dbus.service.method('org.mpris.MediaPlayer2')
     def Raise(self):

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -174,7 +174,7 @@ class SoundMenuControls(dbus.service.Object):
             duration_microsec = 0
 
         data = {
-            "mpris:trackid": "/Player/TrackList/" + "_".join(title.strip().split()).replace("/", "_"),
+            "mpris:trackid": "/Player/TrackList/" + self._get_track_id(title),
             "mpris:length": duration_microsec,
             "xesam:album": album,
             "xesam:title": title,
@@ -186,6 +186,9 @@ class SoundMenuControls(dbus.service.Object):
 
         self.set_property("Metadata", dbus.Dictionary(data, "sv", variant_level=1))
 
+    @staticmethod
+    def _get_track_id(title):
+        return "".join(filter(str.isalnum, title))
 
     @dbus.service.method('org.mpris.MediaPlayer2')
     def Raise(self):

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -164,7 +164,10 @@ class SoundMenuControls(dbus.service.Object):
     def set_property(self, name, value):
         self._static_properties[name] = value
 
-    def song_changed(self, artists = None, album = None, title = None, cover = None, duration_microsec = None):
+    def set_properties(self, **kwargs):
+        self._static_properties.update(kwargs)
+
+    def song_changed(self, artists = None, album = None, title = None, cover = None, duration_microsec = 0, properties = {}):
         """song_changed - sets the info for the current song.
 
         This method is not typically overriden. It should be called
@@ -175,6 +178,11 @@ class SoundMenuControls(dbus.service.Object):
             artists - a list of strings representing the artists"
             album - a string for the name of the album
             title - a string for the title of the song
+            cover - a string for the location (URI) of the track image
+            duration_microsec - track duration in microseconds
+            properties - a dictionary of MediaPlayer2.Player properties
+                         that are specific to this track
+                         (e.g. {"CanSeek": False})
 
         """
 
@@ -184,8 +192,6 @@ class SoundMenuControls(dbus.service.Object):
             album = "Album Uknown"
         if title is None:
             title = "Title Uknown"
-        if duration_microsec is None:
-            duration_microsec = 0
 
         data = {
             "mpris:trackid": "/Player/TrackList/" + self._get_track_id(title),
@@ -199,6 +205,7 @@ class SoundMenuControls(dbus.service.Object):
             data["mpris:artUrl"] = cover
 
         self.set_property("Metadata", dbus.Dictionary(data, "sv", variant_level=1))
+        self.set_properties(**properties)
 
     @staticmethod
     def _get_track_id(title):

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -128,7 +128,9 @@ class SoundMenuControls(dbus.service.Object):
             "DesktopEntry": desktop_name
             }
         
-        self._volatile_properties = {}
+        self._volatile_properties = {
+            "Position": lambda: dbus.Int64(self.position_microseconds)
+            }
 
         self.song_changed()
     

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -190,7 +190,7 @@ class SoundMenuControls(dbus.service.Object):
         """Raise
 
         A dbus signal handler for the Raise signal. Do no override this
-        function directly. rather, overrise _sound_menu_raise. This
+        function directly. rather, override _sound_menu_raise. This
         function is typically only called by the Sound, not directly
         from code.
 
@@ -216,7 +216,7 @@ class SoundMenuControls(dbus.service.Object):
         """Quit
 
         A dbus signal handler for the Quit signal. Do no override this
-        function directly. rather, overrise _sound_menu_quit. This
+        function directly. rather, override _sound_menu_quit. This
         function is typically only called by the Sound, not directly
         from code.
 
@@ -279,7 +279,7 @@ class SoundMenuControls(dbus.service.Object):
         """Next
 
         A dbus signal handler for the Next signal. Do no override this
-        function directly. Rather, overide _sound_menu_next. This
+        function directly. Rather, override _sound_menu_next. This
         function is typically only called by the Sound, not directly
         from code.
 
@@ -292,7 +292,7 @@ class SoundMenuControls(dbus.service.Object):
 
         This function is called when the user has clicked
         the next button in the Sound Indicator. Implementations
-        should overrirde this function in order to a function to
+        should override this function in order to a function to
         advance to the next track. Implementations should call
         song_changed() and sound_menu.signal_playing() in order to
         keep the song information in the sound menu in sync.
@@ -307,7 +307,7 @@ class SoundMenuControls(dbus.service.Object):
         """Previous
 
         A dbus signal handler for the Previous signal. Do no override this
-        function directly. Rather, overide _sound_menu_previous. This
+        function directly. Rather, override _sound_menu_previous. This
         function is typically only called by the Sound Menu, not directly
         from code.
 
@@ -321,7 +321,7 @@ class SoundMenuControls(dbus.service.Object):
 
         This function is called when the user has clicked
         the previous button in the Sound Indicator. Implementations
-        should overrirde this function in order to a function to
+        should override this function in order to a function to
         advance to the next track. Implementations should call
         song_changed() and  sound_menu.signal_playing() in order to
         keep the song information in sync.
@@ -337,7 +337,7 @@ class SoundMenuControls(dbus.service.Object):
         """Next
 
         A dbus signal handler for the Next signal. Do no override this
-        function directly. Rather, overide _sound_menu_next. This
+        function directly. Rather, override _sound_menu_next. This
         function is typically only called by the Sound, not directly
         from code.
 
@@ -394,7 +394,7 @@ class SoundMenuControls(dbus.service.Object):
         """_sound_menu_is_playing
 
         Check if the the player is playing,.
-        Implementations should overrirde this function
+        Implementations should override this function
         so that the Sound Menu can check whether to display
         Play or Pause functionality.
 
@@ -414,10 +414,10 @@ class SoundMenuControls(dbus.service.Object):
     def _sound_menu_pause(self):
         """_sound_menu_pause
 
-        Reponds to the Sound Menu when the user has click the
+        Responds to the Sound Menu when the user has clicked the
         Pause button.
 
-        Implementations should overrirde this function
+        Implementations should override this function
         to pause playback when called.
 
         The default implementation of this function does nothing
@@ -428,17 +428,17 @@ class SoundMenuControls(dbus.service.Object):
         returns:
             None
 
-       """
+        """
 
         pass
 
     def _sound_menu_play(self):
         """_sound_menu_play
 
-        Reponds to the Sound Menu when the user has click the
+        Responds to the Sound Menu when the user has clicked the
         Play button.
 
-        Implementations should overrirde this function
+        Implementations should override this function
         to play playback when called.
 
         The default implementation of this function does nothing
@@ -449,14 +449,14 @@ class SoundMenuControls(dbus.service.Object):
         returns:
             None
 
-       """
+        """
 
         pass
     
     def _sound_menu_stop(self):
         """_sound_menu_play
 
-        Reponds to the Sound Menu when the user has clicked the
+        Responds to the Sound Menu when the user has clicked the
         Stop button.
 
         Implementations should override this function

--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -125,11 +125,25 @@ class SoundMenuControls(dbus.service.Object):
             "CanRaise": True,
             "HasTrackList": False,
             "Identity": identity,
-            "DesktopEntry": desktop_name
+            "DesktopEntry": desktop_name,
+            "Rate": 1.0,
+            "MinimumRate": 1.0,
+            "MaximumRate": 1.0,
+            "CanGoNext": True,
+            "CanGoPrevious": True,
+            "CanPlay": True,
+            "CanPause": True,
+            "CanSeek": True,
+            "CanControl": True,
             }
         
         self._volatile_properties = {
-            "Position": lambda: dbus.Int64(self.position_microseconds)
+            "Position": lambda: dbus.Int64(self.position_microseconds),
+            "Volume": self._sound_menu_get_volume
+            }
+
+        self._properties_setters = {
+            "Volume": self._sound_menu_set_volume
             }
 
         self.song_changed()
@@ -264,7 +278,8 @@ class SoundMenuControls(dbus.service.Object):
         be overriden or called directly.
 
         """
-        self.set_property(prop, value)
+        if prop in self._properties_setters:
+            self._properties_setters[prop](value)
 
     @dbus.service.method(dbus.PROPERTIES_IFACE, in_signature='s', out_signature='a{sv}')
     def GetAll(self, interface):
@@ -477,6 +492,32 @@ class SoundMenuControls(dbus.service.Object):
 
         """
         
+        pass
+
+    @dbus.service.method('org.mpris.MediaPlayer2.Player', signature='x')
+    def Seek(self, offset):
+        self._sound_menu_seek(offset)
+
+    def _sound_menu_seek(self, offset):
+        pass
+
+    @dbus.service.method('org.mpris.MediaPlayer2.Player', signature='ox')
+    def SetPosition(self, track_id, position):
+        self._sound_menu_set_position(position)
+
+    def _sound_menu_set_position(self, position):
+        pass
+
+    def _sound_menu_get_volume(self):
+        """Implementations should override this function
+        to return the correct value
+        """
+        return 1.0
+
+    def _sound_menu_set_volume(value):
+        """Implementations should override this function
+        to set the volume level to _value_
+        """
         pass
 
     @dbus.service.signal(dbus.PROPERTIES_IFACE, signature='sa{sv}as')


### PR DESCRIPTION
Foobnix contained MPRIS implementation that was not full and, partially, did not agree with the specification given [here](https://specifications.freedesktop.org/mpris-spec/latest/). This led to some problems with using media keys and media applet in Plasma 5 with Foobnix (don't know about the other environments). This is an effort to make MPRIS interface implementation more correct according to the given specification.

It also worth mentioning that I made the engine notify the interface about the new track playing **after** the playing thread starts, in order to have an information on the track duration in that moment. If this needs to be reverted, I can think on the other ways of obtaining this information.