### PR TITLE
Implement Pause method of MPRIS D-Bus interface

### DIFF
--- a/foobnix/thirdparty/sound_menu.py
+++ b/foobnix/thirdparty/sound_menu.py
@@ -382,6 +382,11 @@ class SoundMenuControls(dbus.service.Object):
     def Play(self):
         self._sound_menu_play()
         self.signal_playing()
+
+    @dbus.service.method('org.mpris.MediaPlayer2.Player')
+    def Pause(self):
+        self._sound_menu_pause()
+        self.signal_paused()
         
     @dbus.service.method('org.mpris.MediaPlayer2.Player')
     def Stop(self):


### PR DESCRIPTION
When implementing version 2 of MPRIS D-Bus interface in #136 I implemented Play and PlayPause methods of the player interface but apparently missed a [Pause](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Pause) method. This patch simply adds a missing implementation thus allowing a proper usage of external player controllers using that method of MPRIS interface (for example, media player applet in newer versions of Plasma 5).