### PR TITLE
Disable last.fm service if no account is provided

### DIFF
--- a/foobnix/gui/base_controls.py
+++ b/foobnix/gui/base_controls.py
@@ -447,6 +447,7 @@ class BaseFoobnixControls():
         if bean.type != FTYPE_RADIO:
             self.update_info_panel(bean)
         self.set_visible_video_panel(False)
+        self.trayicon.update_info_from(bean)
 
     @idle_task
     def notify_playing(self, pos_sec, dur_sec, bean):

--- a/foobnix/gui/service/lastfm_service.py
+++ b/foobnix/gui/service/lastfm_service.py
@@ -86,13 +86,21 @@ class LastFmService():
         return self.init_thread()
 
     def init_thread(self):
-        time.sleep(5)
-        if not self.controls.net_wrapper.is_internet():
+        username = FCBase().lfm_login
+        password = FCBase().lfm_password
+
+        if not username or username == "l_user_" or not password:
+            logging.debug("No last.fm account provided")
             return None
 
+        if not self.controls.net_wrapper.is_internet():
+            # try again...
+            time.sleep(5)
+            if not self.controls.net_wrapper.is_internet():
+                return None
+
         logging.debug("RUN INIT LAST.FM")
-        username = FCBase().lfm_login
-        password_hash = pylast.md5(FCBase().lfm_password)
+        password_hash = pylast.md5(password)
         self.cache = None
         try:
             self.network = pylast.get_lastfm_network(api_key=API_KEY,


### PR DESCRIPTION
Disables last.fm service if no account is provided. This allows to avoid unnecessary login attempts. Also (and that was actually the main reason for doing this) this pull request tries to mitigate the issue with application freezes caused by this module due to `time.sleep()` calls before checking internet connection status. This part is more a temporary solution though, a more complete fix involving reworking the system of internet connectivity management is probably still desirable.